### PR TITLE
Mention that AuthUser is managed internally

### DIFF
--- a/reference/login.md
+++ b/reference/login.md
@@ -65,3 +65,8 @@ export default async function (req) {
 You can even restrict a user's access to only their own comments;
 please see ["Restricting Data Access to Matching
 User"](pol#restricting-data-access-to-matching-user).
+
+:::note
+AuthUser instances are managed by ChiselStrike.  Trying to create or destroy
+them in your code will faill with an error.
+:::


### PR DESCRIPTION
Sync up a change that got dropped when we did the switch to new documentation:

https://github.com/chiselstrike/chiselstrike/commit/0c389301360ef5adad45d6cf0347700f01a79f1f