### PR TITLE
Fix quoting in secrets reference documentation

### DIFF
--- a/reference/secrets.md
+++ b/reference/secrets.md
@@ -50,7 +50,7 @@ our secrets. But it's great for a demo!
 We can now ask for one of our secrets
 
 ```console
-curl localhost:8080/dev/secrets?secret=secret1
+curl "localhost:8080/dev/secrets?secret=secret1"
 ```
 
 and receive:
@@ -62,7 +62,7 @@ and receive:
 or fetch another one of our secrets, that is a JSON object instead of a string:
 
 ```console
-curl localhost:8080/dev/secrets?secret=secret2
+curl "localhost:8080/dev/secrets?secret=secret2"
 ```
 
 and receive it back:


### PR DESCRIPTION
If you do `curl` without quoting on URLs that have a question mark, for example, `zhs` on mac complains as follows:

zsh: no matches found: localhost:8080/dev/secrets?secret=secret1

Fix it up.