### PR TITLE
Use ChiselStrike 0.12.1 in tutorial

### DIFF
--- a/tutorials/getting-started/step-01.md
+++ b/tutorials/getting-started/step-01.md
@@ -11,7 +11,7 @@ Change to the directory where you want to create the project. Run the following
 command:
 
 ```bash
-npx create-chiselstrike-app@latest my-backend
+npx create-chiselstrike-app@0.12.1 my-backend
 ```
 
 :::tip


### PR DESCRIPTION
In preparation for releasing 0.13 that has new routing API and CRUD API changes, let's switch tutorial to use 0.12.1 until documentation gets updated.